### PR TITLE
Support for indirect tables

### DIFF
--- a/p4runtime_sh/utils.py
+++ b/p4runtime_sh/utils.py
@@ -15,3 +15,14 @@ class UserError(Exception):
     # TODO(antonin): is this the best way to get a custom traceback?
     def _render_traceback_(self):
         return [str(self)]
+
+
+class InvalidP4InfoError(Exception):
+    def __init__(self, info=""):
+        self.info = info
+
+    def __str__(self):
+        return "Invalid P4Info message: {}".format(self.info)
+
+    def _render_traceback_(self):
+        return [str(self)]


### PR DESCRIPTION
 * support for ActionProfileMember and ActionProfileGroup
 * support for indirect match table entries (using a member id or group
   id as their action spec)

Support for one-shot group programming has not been added yet.

This commit also refactors all the P4Runtime entities in the shell to
inherit from a common class, _EntityBase, which implements the common
functionality.

Fixes #6