### PR TITLE
Add support for DirectCounterEntry messages

### DIFF
--- a/p4runtime_sh/p4runtime.py
+++ b/p4runtime_sh/p4runtime.py
@@ -264,6 +264,8 @@ class P4RuntimeClient:
         req.updates.extend([update])
         return self.stub.Write(req)
 
+    # Decorator is useless here: in case of server error, the exception is raised during the
+    # iteration (when next() is called).
     @parse_p4runtime_error
     def read_one(self, entity):
         req = p4runtime_pb2.ReadRequest()


### PR DESCRIPTION
We don't support the counter_data field in the TableEntry message yet,
so everything has to be done through the DirectCounterEntry message.

This commit also improves support for read operations (gRPC errors are
now intercepted correctly and translated into P4RuntimeException).