### PR TITLE
Support for MulticastGroupEntry and CloneSessionEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ about P4Info objects.
 
 `table_entry`, `action_profile_member`, `action_profile_group`, `counter_entry`,
 `direct_counter_entry`, `meter_entry`, `direct_meter_entry` (named after the
-P4Runtime `Entity` fields) for runtime entity programming.
+P4Runtime `Entity` fields), along with `multicast_group_entry` and
+`clone_session_entry`, for runtime entity programming.
 
 The `Write` command can be used to read a `WriteRequest` message from a file
 (for now, Protobuf text format only) and send it to a server:

--- a/p4runtime_sh/context.py
+++ b/p4runtime_sh/context.py
@@ -52,6 +52,7 @@ class P4RuntimeEntity(enum.Enum):
     direct_meter_entry = 5
     counter_entry = 6
     direct_counter_entry = 7
+    packet_replication_engine_entry = 8
 
 
 class Context:

--- a/usage/pre.md
+++ b/usage/pre.md
@@ -1,0 +1,55 @@
+```python
+*** Welcome to the IPython shell for P4Runtime ***
+P4Runtime sh >>> mcge = multicast_group_entry(1)                                                                                                                                                     
+
+P4Runtime sh >>> mcge.add(1, 1).add(1, 2).add(2, 3)                                                                                                                                                  
+Out[2]: 
+multicast_group_entry {
+  multicast_group_id: 1
+  replicas {
+    egress_port: 1
+    instance: 1
+  }
+  replicas {
+    egress_port: 1
+    instance: 2
+  }
+  replicas {
+    egress_port: 2
+    instance: 3
+  }
+}
+
+
+P4Runtime sh >>> mcge.insert                                                                                                                                                                         
+
+P4Runtime sh >>>
+```
+
+```python
+*** Welcome to the IPython shell for P4Runtime ***
+P4Runtime sh >>> cse = clone_session_entry(1)                                                                                                                                                        
+
+P4Runtime sh >>> cse.add(1, 1).add(1, 2).add(2, 3)                                                                                                                                                   
+Out[2]: 
+clone_session_entry {
+  session_id: 1
+  replicas {
+    egress_port: 1
+    instance: 1
+  }
+  replicas {
+    egress_port: 1
+    instance: 2
+  }
+  replicas {
+    egress_port: 2
+    instance: 3
+  }
+}
+
+
+P4Runtime sh >>> cse.insert                                                                                                                                                                          
+
+P4Runtime sh >>>
+```


### PR DESCRIPTION
We do not expose PacketReplicationEngineEntry for now as it is more
convenient to access the one-of message fields directly.

See usage/pre.md.

Fixes #16