### PR TITLE
Enable shell objects to be used programmatically in Python scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,34 @@ P4Runtime sh >>> table_entry["FabricIngress.forwarding.routing_v4"].read(lambda 
 
 P4Runtime sh >>>
 ```
+
+## Using p4runtime-shell in scripts
+
+You can also leverage this project as a convenient P4Runtime wrapper to
+programmatically program switches using Pyhton scripts:
+
+```python
+import p4runtime_sh.shell as sh
+
+# you can omit the config argument if the switch is already configured with the
+# correct P4 dataplane.
+sh.setup(
+    device_id=1,
+    grpc_addr='localhost:50051',
+    election_id=(0, 1), # (high, low)
+    config=sh.FwdPipeConfig('config/p4info.pb.txt', 'config/device_config.bin')
+)
+
+# see p4runtime_sh/test.py for more examples
+te = sh.TableEntry('<table_name>')(action='<action_name>')
+te.match['<name>'] = '<value>'
+te.action['<name>'] = '<value>'
+te.insert()
+
+# ...
+
+sh.teardown()
+```
+
+Note that at the moment the P4Runtime client object is a global variable, which
+means that we only support one P4Runtime connection to a single switch.

--- a/p4runtime_sh/test.py
+++ b/p4runtime_sh/test.py
@@ -126,14 +126,13 @@ class UnitTestCase(BaseTestCase):
         self.servicer.Read = Mock(spec=[], return_value=p4runtime_pb2.ReadResponse())
         p4runtime_pb2_grpc.add_P4RuntimeServicer_to_server(self.servicer, self.server)
 
-        sh.client = sh.P4RuntimeClient(self.device_id, self.grpc_addr, (0, 1))
-        sh.client.set_fwd_pipe_config(self._p4info_path, self._config_path)
-        self.p4info = sh.client.get_p4info()
-        sh.context.set_p4info(self.p4info)
+        sh.setup(device_id=self.device_id,
+                 grpc_addr=self.grpc_addr,
+                 election_id=self.election_id,
+                 config=sh.FwdPipeConfig(self._p4info_path, self._config_path))
 
     def tearDown(self):
-        sh.client.tear_down()
-        sh.client = None
+        sh.teardown()
         super().tearDown()
 
     def make_write_request(self, update_type, entity_type, expected_txt):


### PR DESCRIPTION
In particular, add a setup() and a teardown() method to shell.py.