### PR TITLE
Integrate with codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *test*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.pyc
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ install:
 
 script:
   - docker run -ti p4lang/p4runtime-sh-dev bash -c "source venv/bin/activate && flake8 p4runtime_sh config_builders"
-  - docker run -ti p4lang/p4runtime-sh-dev bash -c "source venv/bin/activate && nose2 p4runtime_sh config_builders"
+  - ci_env=`bash <(curl -s https://codecov.io/env)`
+  - docker run $ci_env -ti p4lang/p4runtime-sh-dev bash -c "source venv/bin/activate && nose2 --with-coverage p4runtime_sh config_builders && codecov"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,13 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /p4runtime-sh/
 
+ENV PKG_DEPS git
+
+# git is required for codecov
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $PKG_DEPS && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
 RUN source $VENV/bin/activate && \
     pip3 install -r requirements-dev.txt && \
     rm -rf ~/.cache/pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8
 nose2
 callee
+codecov

--- a/unittest.cfg
+++ b/unittest.cfg
@@ -1,0 +1,6 @@
+[coverage]
+always-on = False
+coverage = config_builders
+           p4runtime_sh
+coverage-config = .coveragerc
+coverage-report = 


### PR DESCRIPTION
nose2 is run with --with-coverage to report coverage information which
is then uploaded to codecov.

Fixes #21