### PR TITLE
Do not spawn new processes in unit tests

### DIFF
--- a/config_builders/test_tofino.py
+++ b/config_builders/test_tofino.py
@@ -13,33 +13,81 @@
 # limitations under the License.
 #
 
+from io import StringIO
+import nose2.tools
 from tempfile import NamedTemporaryFile
-from tofino import build_config
+import tofino
 import unittest
+import unittest.mock
 
 
 class TestTofinoConfigBuilder(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.prog_name = "myprog"
+
+    def setUp(self):
+        super().setUp()
+        self.ctx_json_f = NamedTemporaryFile(mode='w', delete=True)
+        self.bin_f = NamedTemporaryFile(mode='wb', delete=True)
+        self.out_f = NamedTemporaryFile(mode='rb', delete=True)
+
+    def tearDown(self):
+        # There is no harm in calling close multiple times.
+        self.ctx_json_f.close()
+        self.bin_f.close()
+        self.out_f.close()
+        super().tearDown()
+
+    def write_inputs(self):
+        self.ctx_json_f.write("{}")
+        self.bin_f.write(b"\xab")
+        # we need to flush since build_config will open and read these files,
+        # while we keep them also open here until we tear down the test.
+        self.ctx_json_f.flush()
+        self.bin_f.flush()
+
+        expected_out = b""
+        expected_out += b"\x06\x00\x00\x00"  # length of "myprog"
+        expected_out += b"myprog"
+        expected_out += b"\x01\x00\x00\x00"  # length of "\xab"
+        expected_out += b"\xab"
+        expected_out += b"\x02\x00\x00\x00"  # length of "{}"
+        expected_out += b"{}"
+
+        return expected_out
+
     def test_build_config(self):
-        prog_name = "myprog"
-        # when breaking-up the line with '\', we get a false positive with flake8 (3.7.7) for E122,
-        # that cannot be disabled with a noqa comment.
-        with NamedTemporaryFile(mode='w') as ctx_json_f, NamedTemporaryFile(mode='wb') as bin_f, NamedTemporaryFile(mode='rb') as out_f:  # noqa: E501
-            ctx_json_f.write("{}")
-            bin_f.write(b"\xab")
-            # we need to flush since build_config will open and read these
-            # files, while we keep them also open here until we leave the
-            # context manager
-            ctx_json_f.flush()
-            bin_f.flush()
+        expected_out = self.write_inputs()
+        tofino.build_config(self.prog_name, self.ctx_json_f.name, self.bin_f.name, self.out_f.name)
+        self.assertEqual(self.out_f.read(), expected_out)
 
-            build_config(prog_name, ctx_json_f.name, bin_f.name, out_f.name)
+    def make_args(self):
+        args = ["tofino.py",
+                "--ctx-json", self.ctx_json_f.name,
+                "--tofino-bin", self.bin_f.name,
+                "-o", self.out_f.name,
+                "-p", self.prog_name]
+        return args
 
-            expected_out = b""
-            expected_out += b"\x06\x00\x00\x00"  # length of "myprog"
-            expected_out += b"myprog"
-            expected_out += b"\x01\x00\x00\x00"  # length of "\xab"
-            expected_out += b"\xab"
-            expected_out += b"\x02\x00\x00\x00"  # length of "{}"
-            expected_out += b"{}"
+    def test_build_config_main(self):
+        expected_out = self.write_inputs()
+        args = self.make_args()
+        with unittest.mock.patch('sys.argv', args):
+            try:
+                tofino.main()
+            except SystemExit:
+                self.fail("Error when calling tofino.main")
+        self.assertEqual(self.out_f.read(), expected_out)
 
-            self.assertEqual(out_f.read(), expected_out)
+    @nose2.tools.params('ctx_json_f', 'bin_f')
+    def test_bad_input_path(self, input_f):
+        self.write_inputs()
+        args = self.make_args()
+        # We will call close() again in tearDown(), which is fine.
+        getattr(self, input_f).close()
+        with unittest.mock.patch('sys.argv', args):
+            with unittest.mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                with self.assertRaises(SystemExit):
+                    tofino.main()
+                self.assertIn("is not a valid file", mock_stdout.getvalue())

--- a/config_builders/tofino.py
+++ b/config_builders/tofino.py
@@ -72,5 +72,5 @@ def main():
     build_config(args.name, args.ctx_json, args.tofino_bin, args.out)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     main()

--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -2436,5 +2436,5 @@ def main():
     client.tear_down()
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     main()


### PR DESCRIPTION
As it makes coverage tracking more complicated
(https://coverage.readthedocs.io/en/latest/subprocess.html).

Instead we invoke the main() function directly and patch sys.argv
appropriately. For tests involving IPython, we need to make sure that
the IPY_TEST_SIMPLE_PROMPT env variable is set, which we do at the very
beginning of test.py (before anything else is imported). This way we do
not require devs to set it when running the test (which granted we
could do in a wrapper script).