### PR TITLE
Add APIVersion shell command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM p4lang/third-party:stable AS deps
 
 SHELL ["/bin/bash", "-c"]
 
-COPY . /p4runtime-sh/
-WORKDIR /p4runtime-sh/
-
 ENV PKG_DEPS git python3 python3-venv
 ENV VENV /p4runtime-sh/venv
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $PKG_DEPS && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+COPY . /p4runtime-sh/
+WORKDIR /p4runtime-sh/
 
 RUN python3 -m venv $VENV && \
     source $VENV/bin/activate && \

--- a/p4runtime_sh/p4runtime.py
+++ b/p4runtime_sh/p4runtime.py
@@ -276,3 +276,9 @@ class P4RuntimeClient:
         req.device_id = self.device_id
         req.entities.extend([entity])
         return self.stub.Read(req)
+
+    @parse_p4runtime_error
+    def api_version(self):
+        req = p4runtime_pb2.CapabilitiesRequest()
+        rep = self.stub.Capabilities(req)
+        return rep.p4runtime_api_version

--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -2279,6 +2279,14 @@ def Write(input_):
                 input_))
 
 
+def APIVersion():
+    """
+    Returns the version of the P4Runtime API implemented by the server, using
+    the Capabilities RPC.
+    """
+    return client.api_version()
+
+
 # see https://ipython.readthedocs.io/en/stable/config/details.html
 class MyPrompt(Prompts):
     def in_prompt_tokens(self, cli=None):
@@ -2411,6 +2419,7 @@ def main():
         "Replica": Replica,
         "MulticastGroupEntry": MulticastGroupEntry,
         "CloneSessionEntry": CloneSessionEntry,
+        "APIVersion": APIVersion,
     }
 
     for obj_type in P4Type:

--- a/p4runtime_sh/test.py
+++ b/p4runtime_sh/test.py
@@ -40,6 +40,7 @@ import nose2.tools
 class P4RuntimeServicer(p4runtime_pb2_grpc.P4RuntimeServicer):
     def __init__(self):
         self.p4info = p4info_pb2.P4Info()
+        self.p4runtime_api_version = "1.2.0-dev"
 
     def GetForwardingPipelineConfig(self, request, context):
         rep = p4runtime_pb2.GetForwardingPipelineConfigResponse()
@@ -64,6 +65,11 @@ class P4RuntimeServicer(p4runtime_pb2_grpc.P4RuntimeServicer):
                 rep.arbitration.CopyFrom(req.arbitration)
                 rep.arbitration.status.code = code_pb2.OK
                 yield rep
+
+    def Capabilities(self, request, context):
+        rep = p4runtime_pb2.CapabilitiesResponse()
+        rep.p4runtime_api_version = self.p4runtime_api_version
+        return rep
 
 
 class BaseTestCase(unittest.TestCase):
@@ -941,6 +947,10 @@ clone_session_entry {
         self.simple_read_check(
             expected_req.updates[0].entity, cse, P4RuntimeEntity.packet_replication_engine_entry,
             expect_iterator=False)
+
+    def test_p4runtime_api_version(self):
+        version = sh.APIVersion()
+        self.assertEqual(version, self.servicer.p4runtime_api_version)
 
 
 class P4RuntimeClientTestCase(BaseTestCase):


### PR DESCRIPTION
To query the P4Runtime API version implemented by the server. The
version string is retrieved through the Capabilities RPC (refer to
P4Runtime specification >= 1.1.0).