### PR TITLE
Use a by default allowed temporary directory to mount the files

### DIFF
--- a/p4runtime-sh-docker
+++ b/p4runtime-sh-docker
@@ -68,7 +68,7 @@ def main():
         fname_p4info = "p4info.pb.txt"
         fname_bin = "config.bin"
 
-        tmpdir = tempfile.mkdtemp()
+        tmpdir = tempfile.mkdtemp(dir="/tmp")
         logging.debug(
             "Created temporary directory '{}', it will be mounted in the docker as '{}'".format(
                 tmpdir, mount_path))


### PR DESCRIPTION
On some OSs Docker imposes restrictions on which paths can be mounted.
See: https://docs.docker.com/docker-for-mac/osxfs/#namespaces

Fixes #35 