### PR TITLE
Remove container after run

### DIFF
--- a/p4runtime-sh-docker
+++ b/p4runtime-sh-docker
@@ -79,7 +79,7 @@ def main():
         new_args.extend(["--config", "{},{}".format(
             os.path.join(mount_path, fname_p4info), os.path.join(mount_path, fname_bin))])
 
-    cmd = ["docker", "run", "-ti"]
+    cmd = ["docker", "run", "-ti", "--rm"]
     cmd.extend(docker_args)
     cmd.append(args.docker_image)
     cmd.extend(new_args)


### PR DESCRIPTION
Current containers linger after each run of p4runtime-shell, consuming resources:

```bash
> docker container ls -a | grep p4lang/p4runtime-sh | wc -l
144
```

This PR add the `--rm` Docker flag to automatically remove them after they exited. Since p4runtime-shell is mainly for interactive use and creates a fresh one every time, removing stopped containers should cause any data loss.