### PR TITLE
Add example to read out table_entry direct_counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ e.g. `table_entry?`.
 Here is some of what you can do when using p4runtime-sh with ONF's
 [fabric.p4](https://github.com/opennetworkinglab/onos/blob/master/pipelines/fabric/src/main/resources/fabric.p4).
 
+More examples of usage can be found in the [usage/ folder](usage/).
+
 ```python
 *** Welcome to the IPython shell for P4Runtime ***
 P4Runtime sh >>> tables

--- a/usage/read_table_entry_counter.md
+++ b/usage/read_table_entry_counter.md
@@ -1,0 +1,60 @@
+## Read `counter_data` for `table_entries`
+
+This example uses the [basic tutorial for Stratum](https://github.com/stratum/tutorial/tree/master/basic).
+The goal is to read out the byte and packet counts for a specific table entry.
+
+```python
+*** Welcome to the IPython shell for P4Runtime ***
+P4Runtime sh >>> ########################## Add table entries 
+            ...: te = table_entry["ingress.table0_control.table0"](action = "ingress.table0_control.set_egress_port") 
+            ...: te.priority = 1 
+            ...: te.match["standard_metadata.ingress_port"] = ("1") 
+            ...: te.action['port'] = ("2") 
+            ...: te.insert() 
+            ...:  
+            ...: te = table_entry["ingress.table0_control.table0"](action = "ingress.table0_control.set_egress_port") 
+            ...: te.priority = 1 
+            ...: te.match["standard_metadata.ingress_port"] = ("2") 
+            ...: te.action['port'] = ("1") 
+            ...: te.insert()                                                                                                                                                                                       
+            ...:                                                                                                                                                                                                   
+field_id: 1
+ternary {
+  value: "\000\001"
+  mask: "\001\377"
+}
+
+param_id: 1
+value: "\000\002"
+
+field_id: 1
+ternary {
+  value: "\000\002"
+  mask: "\001\377"
+}
+
+param_id: 1
+value: "\000\001"
+
+
+P4Runtime sh >>> ########################## Retrieve all table entries and print out counter_data (byte and packet counts) 
+            ...: ########################## (Note: you HAVE to generate traffic on some table entries to see non-zero counters) 
+            ...:  
+            ...: for te in table_entry['ingress.table0_control.table0'].read(): 
+            ...:       # You HAVE to set some te.counter_data field to trigger reading out the counter_data 
+            ...:       te.counter_data.byte_count = 0 
+            ...:       for x in te.read(): 
+            ...:             if x.counter_data.byte_count == 0: 
+            ...:                   print('te.counter_data.byte_count == 0 -> Generate some traffic before reading out the counters') 
+            ...:             else: 
+            ...:                   print('Counter data', x.counter_data) 
+            ...:                                                                                                                                                                                                   
+Counter data byte_count: 1022
+packet_count: 11
+
+Counter data byte_count: 1022
+packet_count: 11
+
+
+P4Runtime sh >>>
+```


### PR DESCRIPTION
I had a hard time finding out how to read out the byte and packet counters for specific table entries.

Adding examples like these can help the user get acquainted to the shell more easily!

For the future, there could also be executable examples using Mininet + bmv2?

[Rendered view](https://github.com/davidgengenbach/p4runtime-shell/blob/master/README.md#read-direct_counter_entry-for-specific-table_entry)

Related: https://github.com/p4lang/p4runtime-shell/issues/40