### PR TITLE
Dockerfile cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
-Dockerfile
+*
+!p4runtime_sh/*
+!p4runtime-sh
+!requirements.txt
+!requirements-dev.txt
+!LICENSE
+!config_builders/*
+!docker_entry_point.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,12 @@
 *
-!p4runtime_sh/*
+!p4runtime_sh
 !p4runtime-sh
 !requirements.txt
 !requirements-dev.txt
+!.coveragerc
+.dockerignore
+!.flake8
 !LICENSE
-!config_builders/*
+!config_builders
 !docker_entry_point.sh
+!unittest.cfg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "p4runtime"]
-	path = p4runtime
-	url = https://github.com/p4lang/p4runtime.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM p4lang/third-party:stable AS deps
+FROM ubuntu:20.04 AS deps
 
 SHELL ["/bin/bash", "-c"]
-
-ENV PKG_DEPS git python3 python3-venv
+ENV PKG_DEPS python3 python3-venv
 ENV VENV /p4runtime-sh/venv
 
 RUN apt-get update && \
@@ -19,36 +18,7 @@ RUN python3 -m venv $VENV && \
     pip3 install -r requirements.txt && \
     rm -rf ~/.cache/pip
 
-ENV PROTO_DIR /p4runtime-sh/p4runtime/proto
-ENV GOOGLE_PROTO_DIR /p4runtime-sh/googleapis
-ENV PROTOS="$PROTO_DIR/p4/v1/p4data.proto \
-$PROTO_DIR/p4/v1/p4runtime.proto \
-$PROTO_DIR/p4/config/v1/p4info.proto \
-$PROTO_DIR/p4/config/v1/p4types.proto \
-$GOOGLE_PROTO_DIR/google/rpc/status.proto \
-$GOOGLE_PROTO_DIR/google/rpc/code.proto"
-ENV PROTOFLAGS "-I$GOOGLE_PROTO_DIR -I$PROTO_DIR"
-ENV PROTO_BUILD_DIR /p4runtime-sh/py_out
-
-RUN source $VENV/bin/activate && \
-    mkdir -p $PROTO_BUILD_DIR && \
-    git clone --depth 1 https://github.com/googleapis/googleapis.git $GOOGLE_PROTO_DIR && \
-    protoc $PROTOS --python_out $PROTO_BUILD_DIR $PROTOFLAGS \
-        --grpc_out $PROTO_BUILD_DIR --plugin=protoc-gen-grpc=$(which grpc_python_plugin) && \
-    touch $PROTO_BUILD_DIR/__init__.py $PROTO_BUILD_DIR/p4/__init__.py \
-        $PROTO_BUILD_DIR/p4/v1/__init__.py $PROTO_BUILD_DIR/p4/config/__init__.py \
-        $PROTO_BUILD_DIR/p4/config/v1/__init__.py $PROTO_BUILD_DIR/google/__init__.py \
-        $PROTO_BUILD_DIR/google/rpc/__init__.py && \
-    rm -rf $GOOGLE_PROTO_DIR
-
-# google.rpc import fails without this, need to figure out why exactly
-RUN source $VENV/bin/activate && \
-    SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])") && \
-    cp -r $PROTO_BUILD_DIR/google/* $SITE_PACKAGES/google/
-
-RUN echo "export PYTHONPATH=\"$PROTO_BUILD_DIR\"" >> $VENV/bin/activate
-
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 LABEL maintainer="Antonin Bas <antonin@barefootnetworks.com>"
 LABEL description="A shell based on ipython3 for P4Runtime"
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ p4runtime-sh is an interactive Python shell for
 
 We recommend that you download the Docker image (~200MB) and use it, but you can
 also build the image directly with:
+
 ```bash
-git clone --recursive https://github.com/p4lang/p4runtime-shell
+git clone https://github.com/p4lang/p4runtime-shell
 cd p4runtime-shell
 docker build -t p4lang/p4runtime-sh .
 ```
 
 Run the shell as follows:
+
 ```bash
 [sudo] docker run -ti p4lang/p4runtime-sh \
   --grpc-addr <server IP>:<server port> \
@@ -29,17 +31,20 @@ The above command will retrieve the forwarding pipeline configuration from the
 P4Runtime server. You can also push a forwarding pipeline configuration with the
 shell (you will need to mount the directory containing the P4Info and binary
 device config in the docker):
+
 ```bash
 [sudo] docker run -ti -v /tmp/:/tmp/ p4lang/p4runtime-sh \
   --grpc-addr <server IP>:<server port> \
   --device-id 0 --election-id 0,1 --config /tmp/p4info.txt,/tmp/bmv2.json
 ```
+
 The above command assumes that the P4Info (p4info.txt) and the binary device
 config (bmv2.json) are under /tmp/.
 
 To make the process more convenient, we provide a wrapper script, which takes
 care of running the docker (including mounting the P4Info and binary device
 config files in the docker if needed):
+
 ```bash
 [sudo] ./p4runtime-sh-docker --grpc-addr <server IP>:<server port> \
   --device-id 0 --election-id 0,1 \
@@ -73,7 +78,8 @@ P4Runtime `Entity` fields), along with `multicast_group_entry` and
 
 The `Write` command can be used to read a `WriteRequest` message from a file
 (for now, Protobuf text format only) and send it to a server:
-```
+
+```text
 Write <path to file encoding WriteRequest message in text format>
 ```
 

--- a/p4runtime_sh/test.py
+++ b/p4runtime_sh/test.py
@@ -442,6 +442,7 @@ group_id: 1
 members {
   member_id: 1
   weight: 1
+  watch: 0
 }
 """
 
@@ -534,6 +535,7 @@ action {
         }
       }
       weight: 1
+      watch: 0
     }
     action_profile_actions {
       action {
@@ -544,6 +546,7 @@ action {
         }
       }
       weight: 2
+      watch: 0
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jedi
 ipython
 protobuf
 grpcio
+p4runtime


### PR DESCRIPTION
 - Use pip3 to install P4Runtime dependencies instead of generating from protobuf
   - Also remove the P4Runtime submodule
 - Bump base image from Ubuntu 16.04 to 20.04
 - Ignores unused files(doc, ...) when building the container

The current container image size is 222MB, the new one will be 162MB