### PR TITLE
Default to canonical representation for bytestrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,32 @@ Write <path to file encoding WriteRequest message in text format>
 Type the command name followed by `?` for information on each command,
 e.g. `table_entry?`.
 
+## Canonical representation of bytestrings
+
+The [P4Runtime
+specification](https://p4.org/p4runtime/spec/v1.3.0/P4Runtime-Spec.html#sec-bytestrings)
+defines a canonical representation for binary strings, which all P4Runtime
+servers must support. This representation can be used to format all binary
+strings (match fields, action parameters, ...) in P4Runtime messages exchanged
+between the client and the server. For legacy reasons, some P4Runtime servers do
+not support the canonical representation and require binary strings to be
+byte-padded according to the bitwidth specified in the P4Info message. While all
+P4Runtime-conformant servers must also accept this legacy format, it can lead to
+read-write asymmetry for P4Runtime entities. For example a client may insert a
+TableEntry using the legacy format for match fields, but when reading the same
+TableEntry back, the server may return a message with match field values in the
+canonical representation. When a client uses the canonical representation,
+read-write symmetry is always guaranteed.
+
+If you are dealing with a legacy server which rejects binary strings formatted
+using the canonical representation (making this server non conformant to the
+specification), you can revert to the byte-padded format by typing the following
+command in the shell:
+
+```python
+P4Runtime sh >>> SetGlobalOption "canonical_bytestrings",False
+```
+
 ## Example usage
 
 Here is some of what you can do when using p4runtime-sh with ONF's

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ specification), you can revert to the byte-padded format by typing the following
 command in the shell:
 
 ```python
-P4Runtime sh >>> SetGlobalOption "canonical_bytestrings",False
+P4Runtime sh >>> global_options["canonical_bytestrings"] = False
 ```
 
 ## Example usage

--- a/p4runtime_sh/bytes_utils.py
+++ b/p4runtime_sh/bytes_utils.py
@@ -14,7 +14,7 @@
 #
 
 from ipaddr import IPv4Address, IPv6Address, AddressValueError
-from . global_options import Options, options_map
+from . global_options import global_options, Options
 from .utils import UserError
 
 
@@ -99,7 +99,7 @@ def to_canonical_bytes(bytes_):
 
 
 def make_canonical_if_option_set(bytes_):
-    if options_map.get_value(Options.canonical_bytestrings):
+    if global_options.get_option(Options.canonical_bytestrings):
         return to_canonical_bytes(bytes_)
     return bytes_
 

--- a/p4runtime_sh/bytes_utils.py
+++ b/p4runtime_sh/bytes_utils.py
@@ -14,6 +14,7 @@
 #
 
 from ipaddr import IPv4Address, IPv6Address, AddressValueError
+from . global_options import Options, options_map
 from .utils import UserError
 
 
@@ -82,6 +83,25 @@ def macAddr_to_bytes(addr):
     if len(bytes_) != 6:
         raise UserBadMacError(addr)
     return bytes(bytes_)
+
+
+def to_canonical_bytes(bytes_):
+    if len(bytes_) == 0:
+        return bytes_
+    num_zeros = 0
+    for b in bytes_:
+        if b != 0:
+            break
+        num_zeros += 1
+    if num_zeros == len(bytes_):
+        return bytes_[:1]
+    return bytes_[num_zeros:]
+
+
+def make_canonical_if_option_set(bytes_):
+    if options_map.get_value(Options.canonical_bytestrings):
+        return to_canonical_bytes(bytes_)
+    return bytes_
 
 
 def parse_value(value_str, bitwidth, base=0):

--- a/p4runtime_sh/global_options.py
+++ b/p4runtime_sh/global_options.py
@@ -1,0 +1,51 @@
+# Copyright 2021 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import enum
+
+
+@enum.unique
+class Options(enum.Enum):
+    canonical_bytestrings = bool
+
+
+class OptionMap:
+    option_defaults = {
+        Options.canonical_bytestrings: True,
+    }
+
+    def __init__(self):
+        self.values = {}
+        self.reset_values()
+
+    def reset_values(self):
+        for option in Options:
+            assert(option in OptionMap.option_defaults)
+            self.values[option] = OptionMap.option_defaults[option]
+
+    def get_value(self, option):
+        assert(option in self.values)
+        return self.values[option]
+
+    def get_all_values(self):
+        return self.values
+
+    def set_value(self, option, value):
+        assert(option in self.values)
+        assert(type(value) == option.value)
+        self.values[option] = value
+
+
+options_map = OptionMap()

--- a/p4runtime_sh/test.py
+++ b/p4runtime_sh/test.py
@@ -28,6 +28,7 @@ from unittest.mock import ANY, Mock, patch
 from p4.v1 import p4runtime_pb2, p4runtime_pb2_grpc
 from p4.config.v1 import p4info_pb2
 from p4runtime_sh.context import P4Type, P4RuntimeEntity
+from p4runtime_sh.global_options import options_map
 from p4runtime_sh.p4runtime import P4RuntimeException
 from p4runtime_sh.utils import UserError
 import nose2.tools
@@ -156,6 +157,8 @@ class UnitTestCase(BaseTestCase):
         self.servicer.Read = Mock(spec=[], return_value=p4runtime_pb2.ReadResponse())
         p4runtime_pb2_grpc.add_P4RuntimeServicer_to_server(self.servicer, self.server)
 
+        options_map.reset_values()
+
         sh.setup(device_id=self.device_id,
                  grpc_addr=self.grpc_addr,
                  election_id=self.election_id,
@@ -252,7 +255,7 @@ class UnitTestCase(BaseTestCase):
 
     def test_table_entry_exact(self):
         te = sh.TableEntry("ExactOne")(action="actionA")
-        te.match["header_test.field32"] = "0x12345678"
+        te.match["header_test.field32"] = "0x123456"
         te.action["param"] = "aa:bb:cc:dd:ee:ff"
         te.insert()
 
@@ -261,7 +264,7 @@ table_id: 33582705
 match {
   field_id: 1
   exact {
-    value: "\\x12\\x34\\x56\\x78"
+    value: "\\x12\\x34\\x56"
   }
 }
 action {
@@ -279,6 +282,61 @@ action {
             p4runtime_pb2.Update.INSERT, P4RuntimeEntity.table_entry, expected_entry)
 
         self.servicer.Write.assert_called_once_with(ProtoCmp(expected_req), ANY)
+
+    def test_canonical_bytestrings_on_off(self):
+        def get_te():
+            te = sh.TableEntry("ExactOne")(action="actionA")
+            te.match["header_test.field32"] = "0x0"
+            te.action["param"] = "00:00:11:00:22:33"
+            return te
+
+        expected_entry = """
+table_id: 33582705
+match {
+  field_id: 1
+  exact {
+    value: "\\x00"
+  }
+}
+action {
+  action {
+    action_id: 16783703
+    params {
+      param_id: 1
+      value: "\\x11\\x00\\x22\\x33"
+    }
+  }
+}
+"""
+        get_te().insert()
+        expected_req = self.make_write_request(
+            p4runtime_pb2.Update.INSERT, P4RuntimeEntity.table_entry, expected_entry)
+        self.servicer.Write.assert_called_with(ProtoCmp(expected_req), ANY)
+
+        sh.SetGlobalOption("canonical_bytestrings", False)  # enable legacy (byte-padded) format
+
+        expected_entry = """
+table_id: 33582705
+match {
+  field_id: 1
+  exact {
+    value: "\\x00\\x00\\x00\\x00"
+  }
+}
+action {
+  action {
+    action_id: 16783703
+    params {
+      param_id: 1
+      value: "\\x00\\x00\\x11\\x00\\x22\\x33"
+    }
+  }
+}
+"""
+        get_te().insert()
+        expected_req = self.make_write_request(
+            p4runtime_pb2.Update.INSERT, P4RuntimeEntity.table_entry, expected_entry)
+        self.servicer.Write.assert_called_with(ProtoCmp(expected_req), ANY)
 
     @nose2.tools.params(("10.0.0.0/16", "\\x0a\\x00\\x00\\x00", 16),
                         ("10.0.240.0/20", "\\x0a\\x00\\xf0\\x00", 20),
@@ -370,8 +428,8 @@ table_id: 33603558
 match {
   field_id: 1
   range {
-    low: "\\x00\\x00\\x00\\x00"
-    high: "\\x00\\x00\\x04\\x00"
+    low: "\\x00"
+    high: "\\x04\\x00"
   }
 }
 action {
@@ -974,6 +1032,20 @@ clone_session_entry {
     def test_p4runtime_api_version(self):
         version = sh.APIVersion()
         self.assertEqual(version, self.servicer.p4runtime_api_version)
+
+    def test_global_options(self):
+        option_name = "canonical_bytestrings"
+        options = sh.GetGlobalOptions()
+        self.assertEqual(options[option_name], True)
+        sh.SetGlobalOption(option_name, False)
+        value = sh.GetGlobalOption(option_name)
+        self.assertEqual(value, False)
+
+    def test_global_options_invalid(self):
+        with self.assertRaisesRegex(UserError, "Unknown option name"):
+            sh.GetGlobalOption("foo")
+        with self.assertRaisesRegex(UserError, "Invalid value type"):
+            sh.SetGlobalOption("canonical_bytestrings", "bar")
 
 
 class P4RuntimeClientTestCase(BaseTestCase):


### PR DESCRIPTION
Following https://github.com/p4lang/PI/pull/538, we default to the
canonical bytestring representation for match fields and action
parameters. This ensures read-write symmetry for for TableEntry
messages. When using a P4Runtime server which does not support the
canonical representation but relies on the legacy (byte-padded) format,
one can revert to the previous behavior by using the following command:

```python
P4Runtime sh >>> global_options["canonical_bytestrings"] = False
```