### PR TITLE
Adopt more inclusive terminology

### DIFF
--- a/p4runtime_sh/p4runtime.py
+++ b/p4runtime_sh/p4runtime.py
@@ -191,11 +191,11 @@ class P4RuntimeClient:
         if rep is None:
             logging.critical("Failed to establish session with server")
             sys.exit(1)
-        is_master = (rep.arbitration.status.code == code_pb2.OK)
+        is_primary = (rep.arbitration.status.code == code_pb2.OK)
         logging.debug("Session established, client is '{}'".format(
-            'master' if is_master else 'slave'))
-        if not is_master:
-            print("You are not master, you only have read access to the server")
+            'primary' if is_primary else 'backup'))
+        if not is_primary:
+            print("You are not the primary client, you only have read access to the server")
 
     def get_stream_packet(self, type_, timeout=1):
         start = time.time()

--- a/p4runtime_sh/test.py
+++ b/p4runtime_sh/test.py
@@ -992,7 +992,7 @@ class P4RuntimeClientTestCase(BaseTestCase):
         self.servicer.StreamChannel = Mock(spec=[])
         p4runtime_pb2_grpc.add_P4RuntimeServicer_to_server(self.servicer, self.server)
 
-    def test_arbitration_slave(self):
+    def test_arbitration_backup(self):
         def StreamChannelMock(request_iterator, context):
             for req in request_iterator:
                 if req.HasField('arbitration'):
@@ -1004,6 +1004,6 @@ class P4RuntimeClientTestCase(BaseTestCase):
 
         with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
             client = sh.P4RuntimeClient(self.device_id, self.grpc_addr, (0, 1))
-            self.assertIn("You are not master", mock_stdout.getvalue())
+            self.assertIn("You are not the primary client", mock_stdout.getvalue())
             self.servicer.StreamChannel.assert_called_once_with(ANY, ANY)
             client.tear_down()


### PR DESCRIPTION
Remove harmful language from the project: references to "master" /
"slave" are removed and replaced with "primary" / "backup" to match the
latest version of the P4Runtime specification.

See #57