### PR TITLE
Remove references to "master" branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A shell for P4Runtime
 
-[![Build Status](https://travis-ci.org/p4lang/p4runtime-shell.svg?branch=master)](https://travis-ci.org/p4lang/p4runtime-shell)
+[![Build Status](https://travis-ci.org/p4lang/p4runtime-shell.svg?branch=main)](https://travis-ci.org/p4lang/p4runtime-shell)
 
 **This is still a work in progress. Feedback is welcome.**
 


### PR DESCRIPTION
After renaming the default branch to "main".

See #57