### PR TITLE
Add support for `watch_port` on `ActionProfileGroup` members

### DIFF
--- a/p4runtime_sh/test.py
+++ b/p4runtime_sh/test.py
@@ -564,7 +564,6 @@ group_id: 1
 members {
   member_id: 1
   weight: 1
-  watch: 0
 }
 """
 
@@ -676,7 +675,6 @@ action {
         }
       }
       weight: 1
-      watch: 0
     }
     action_profile_actions {
       action {
@@ -687,7 +685,6 @@ action {
         }
       }
       weight: 2
-      watch: 0
     }
   }
 }


### PR DESCRIPTION
This change exposes the newer `watch_port` field on `ActionProfileGroup` members to the shell. The deprecated `watch` field remains supported, but is not set to 0 by default anymore, as that would set the now `oneof` type watch_kind field if no parameter is given.