### PR TITLE
Upgrade ipython version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,12 @@ setup(
     name = "p4runtime-shell",
     version = "0.0.2",
     packages = find_packages("."),
+    python_requires='>=3.6',
     install_requires = [
         "ipaddr==2.2.0",
         "jedi==0.17.2",
-        "ipython==7.19.0",
+        "ipython>=7.31.1,==7.31.*;python_version>='3.7'",
+        "ipython>=7.16.3,==7.16.*;python_version<'3.7'",
         "protobuf==3.14.0",
         "grpcio==1.35.0",
         "p4runtime==1.3.0",


### PR DESCRIPTION
-> 7.31.1 for Python 3.7+
-> 7.16.3 for Python 3.6 (before this using Python 3.6 wasn 't possible)

This is in response to an ipython CVE:
https://ipython.readthedocs.io/en/stable/whatsnew/version8.html#ipython-8-0-1-cve-2022-21699

We also set the min required Python version to 3.6 in setup.py. It's
possible that older Python 3 versions would work, but I haven't checked.