### PR TITLE
Add TOC to README

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -1,0 +1,20 @@
+name: TOC
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+jobs:
+  toc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check-out code
+      uses: actions/checkout@v2
+    - name: Update TOCs
+      run: make toc
+    - name: Check for changes
+      run: |
+        [ -z "$(git status --untracked-files=no --porcelain)" ]

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 dist
 *.egg-info
 .vscode
+gh-md-toc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all: build
+
+.PHONY: build
+build:
+	docker build -t p4lang/p4runtime-sh .
+
+.PHONY: toc
+toc:
+	@curl -s https://raw.githubusercontent.com/ekalinin/github-markdown-toc/master/gh-md-toc -o gh-md-toc
+	@chmod +x gh-md-toc
+	@./gh-md-toc --insert --no-backup --hide-footer README.md
+
+.PHONY: clean
+clean:
+	rm -rf gh-md-toc

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ p4runtime-sh is an interactive Python shell for
 [P4Runtime](https://github.com/p4lang/p4runtime) based on
 [IPython](https://ipython.org/).
 
+<!--ts-->
+* [A shell for P4Runtime](#a-shell-for-p4runtime)
+   * [Using the shell](#using-the-shell)
+      * [Run with Docker](#run-with-docker)
+      * [Run without Docker](#run-without-docker)
+   * [Available commands](#available-commands)
+   * [Canonical representation of bytestrings](#canonical-representation-of-bytestrings)
+   * [Example usage](#example-usage)
+   * [Using p4runtime-shell in scripts](#using-p4runtime-shell-in-scripts)
+   * [Target-specific support](#target-specific-support)
+      * [P4.org Bmv2](#p4org-bmv2)
+      * [Barefoot Tofino](#barefoot-tofino)
+   * [TLS Authentication](#tls-authentication)
+      * [Server Authentication](#server-authentication)
+      * [Mutual Authentication (with client certificate)](#mutual-authentication-with-client-certificate)
+      * [A Mutual Authentication example with bmv2 and self-signed certificates](#a-mutual-authentication-example-with-bmv2-and-self-signed-certificates)
+<!--te-->
+
 ## Using the shell
 
 ### Run with Docker


### PR DESCRIPTION
With a CI job that will fail if the TOC is not up-to-date.
We use https://github.com/ekalinin/github-markdown-toc. It's a bit weird
that it requires access to the Github API, but well...