### PR TITLE
Support Wildcard Read for MulticastGroupEntry

### DIFF
--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -2219,8 +2219,7 @@ Add replicas with <self>.add(<eg_port_1>, <instance_1>).add(<eg_port_2>, <instan
             self.add(r.egress_port, r.instance)
 
     def read(self, function=None):
-        """Generate a P4Runtime Read RPC to read a single MulticastGroupEntry
-        (wildcard reads not supported).
+        """Generate a P4Runtime Read RPC to read MulticastGroupEntry.
         If function is None, return a MulticastGroupEntry instance (or None if
         the provided group id does not exist). If function is not None, function
         is applied to the MulticastGroupEntry instance (if any).
@@ -2240,14 +2239,17 @@ Add replicas with <self>.add(<eg_port_1>, <instance_1>).add(<eg_port_2>, <instan
         self._entry = entry
 
     def _validate_msg(self):
-        if self.group_id == 0:
-            raise UserError("0 is not a valid group_id for MulticastGroupEntry")
+        return True
 
     def add(self, egress_port=None, instance=0):
         """Add a replica to the multicast group."""
         self.replicas.append(Replica(egress_port, instance))
         return self
 
+    def _write(self, type_):
+        if self.group_id == 0:
+            raise UserError("0 is not a valid group_id for MulticastGroupEntry")
+        super()._write(type_)
 
 class CloneSessionEntry(_EntityBase):
     def __init__(self, session_id=0):


### PR DESCRIPTION
This PR is to add feature discussed in Issue https://github.com/p4lang/p4runtime-shell/issues/93

Below methods in MulticastGroupEntry were calling `_validate_msg()` in `class _EntityBase`
```
read()
_write() called by insert(), delete(), modify()
```

Since I could not think of clean way to handle differently based on method `calling _validate_msg()` (allow zero for Read and deny for other methods), I added _write() to MulticastGroupEntry and did validity check there.

Another option was to override `read()` and keep validation code in  `_validate_msg(), but that required copying 46 lines of code which did not look efficient.

BTW, I tested Wildcard Read for `CloneSessionEntry` and it worked. Actually, it simply did not have `_validate_msg()` and BMv2 (P4Runtimer Server to shell) returned error when trying to insert entry with `session_id = 0`. Maybe this is because PSA allows zero value for `session_id` and left as is when P4Runtime spec was updated.