### PR TITLE
Add support for digests

### DIFF
--- a/p4runtime_sh/context.py
+++ b/p4runtime_sh/context.py
@@ -28,6 +28,7 @@ class P4Type(enum.Enum):
     meter = 6
     direct_meter = 7
     controller_packet_metadata = 8
+    digest = 9
 
 
 P4Type.table.p4info_name = "tables"
@@ -38,6 +39,7 @@ P4Type.direct_counter.p4info_name = "direct_counters"
 P4Type.meter.p4info_name = "meters"
 P4Type.direct_meter.p4info_name = "direct_meters"
 P4Type.controller_packet_metadata.p4info_name = "controller_packet_metadata"
+P4Type.digest.p4info_name = "digests"
 
 for obj_type in P4Type:
     obj_type.pretty_name = obj_type.name.replace('_', ' ')
@@ -54,6 +56,7 @@ class P4RuntimeEntity(enum.Enum):
     counter_entry = 6
     direct_counter_entry = 7
     packet_replication_engine_entry = 8
+    digest_entry = 9
 
 
 class Context:


### PR DESCRIPTION
This PR adds support for configuring, receiving and acknowledging digests.

Digests can be configured with `digest_entry`:

```python
d = digest_entry['L2_digest']
d.ack_timeout_ns = 1000000000
d.max_timeout_ns = 1000000000
d.max_list_size = 100
d.insert()
```

`DigestList`s can be received from the in queue:

```python
# async
for e in digest_list.sniff():
    print(e)
# sync
dl = digest_list.digest_list_queue.get()
```

`DigestsAck`s are sent automatically.