### PR TITLE
Fix a bug that caused the controller to hang indefinitely on exit.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ python_requires = >=3.6
 setup_requires =
     setuptools_scm
 install_requires =
+    iterators == 0.2.0
     ipaddr == 2.2.0
     jedi == 0.17.2
     ipython >= 7.31.1, == 7.31.*; python_version>='3.7'


### PR DESCRIPTION
During the teardown process (i.e when issuing quit() command), the controller tries to close all resources including the StreamChannel (StreamChannel is started on controller initaliazation).

StreamChannel events are handled by separated thread, which listens for gRPC messages/replies from the P4Agent, when there is no requests, the StreamChannel blocks, which in turn blocks the thread. As part of the teardown, the controller join() the StreamChannel thread, which does not exit as there are no requests from the P4Agent and thus the controller hangs forever.

The fix uses TimeoutIterator to query StreamChannel events with given timeout, if no events are received the loops continues and thus can check for program termination

This commit adds dependecy on 'iterators' module that implments the TimeoutIterator