### PR TITLE
Add option to make output quieter

### DIFF
--- a/p4runtime_sh/context.py
+++ b/p4runtime_sh/context.py
@@ -62,10 +62,6 @@ class P4RuntimeEntity(enum.Enum):
 class Context:
     def __init__(self):
         self.p4info = None
-        self.do_printing = True
-
-    def set_do_printing(self, do_printing):
-        self.do_printing = do_printing
 
     def set_p4info(self, p4info):
         self.p4info = p4info

--- a/p4runtime_sh/context.py
+++ b/p4runtime_sh/context.py
@@ -62,6 +62,10 @@ class P4RuntimeEntity(enum.Enum):
 class Context:
     def __init__(self):
         self.p4info = None
+        self.do_printing = True
+
+    def set_do_printing(self, do_printing):
+        self.do_printing = do_printing
 
     def set_p4info(self, p4info):
         self.p4info = p4info

--- a/p4runtime_sh/global_options.py
+++ b/p4runtime_sh/global_options.py
@@ -20,6 +20,7 @@ from .utils import UserError
 @enum.unique
 class Options(enum.Enum):
     canonical_bytestrings = bool
+    verbose = bool
 
 
 class UnknownOptionName(UserError):
@@ -43,12 +44,17 @@ class InvalidOptionValueType(UserError):
 class GlobalOptions:
     option_defaults = {
         Options.canonical_bytestrings: True,
+        Options.verose: True,
     }
 
     option_helpstrings = {
         Options.canonical_bytestrings: """
 Use byte-padded legacy format for binary strings sent to the P4Runtime server,
 instead of the canonical representation. See P4Runtime specification for details.
+""",
+        Options.verbose: """
+Print a text style representation of the protobuf contents of P4Runtime
+messages while creating them using methods in the p4runtime-shell package.
 """
     }
 

--- a/p4runtime_sh/global_options.py
+++ b/p4runtime_sh/global_options.py
@@ -17,7 +17,6 @@ import enum
 from .utils import UserError
 
 
-@enum.unique
 class Options(enum.Enum):
     canonical_bytestrings = bool
     verbose = bool
@@ -44,7 +43,7 @@ class InvalidOptionValueType(UserError):
 class GlobalOptions:
     option_defaults = {
         Options.canonical_bytestrings: True,
-        Options.verose: True,
+        Options.verbose: True,
     }
 
     option_helpstrings = {

--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -39,6 +39,7 @@ import queue
 
 context = Context()
 client = None
+verbose = False
 
 
 class UserUsageError(UserError):
@@ -357,13 +358,15 @@ You may also use <self>.set(<f>='<value>')
         fullname = self._full_field_name(name)
         field_info = self._get_mf(fullname)
         self._mk[fullname] = self._parse_mf(value, field_info)
-        print(self._mk[fullname])
+        if verbose:
+            print(self._mk[fullname])
 
     def __getitem__(self, name):
         fullname = self._full_field_name(name)
         f = self._mk.get(fullname, None)
         if f is None:
-            print("Unset")
+            if verbose:
+                print("Unset")
         return f
 
     def _parse_mf(self, s, field_info):
@@ -445,8 +448,9 @@ You may also use <self>.set(<f>='<value>')
                 transformed = True
                 barray[i] = 0
         if transformed:
-            print("LPM value was transformed to conform to the P4Runtime spec "
-                  "(trailing bits must be unset)")
+            if verbose:
+                print("LPM value was transformed to conform to the P4Runtime"
+                      "spec (trailing bits must be unset)")
         mf.lpm.value = bytes(bytes_utils.make_canonical_if_option_set(barray))
         return mf
 
@@ -477,8 +481,9 @@ You may also use <self>.set(<f>='<value>')
                 transformed = True
                 barray[i] = barray[i] & mask[i]
         if transformed:
-            print("Ternary value was transformed to conform to the P4Runtime spec "
-                  "(masked off bits must be unset)")
+            if verbose:
+                print("Ternary value was transformed to conform to the"
+                      " P4Runtime spec (masked off bits must be unset)")
         mf.ternary.value = bytes(bytes_utils.make_canonical_if_option_set(barray))
         mf.ternary.mask = bytes_utils.make_canonical_if_option_set(mask)
         return mf
@@ -598,13 +603,15 @@ class Action:
     def __setitem__(self, name, value):
         param_info = self._get_param(name)
         self._param_values[name] = self._parse_param(value, param_info)
-        print(self._param_values[name])
+        if verbose:
+            print(self._param_values[name])
 
     def __getitem__(self, name):
         _ = self._get_param(name)
         f = self._param_values.get(name, None)
         if f is None:
-            print("Unset")
+            if verbose:
+                print("Unset")
         return f
 
     def _parse_param(self, s, param_info):
@@ -1077,7 +1084,8 @@ class OneshotAction:
             if type(value) is not int:
                 raise UserError("watch must be an integer")
         elif name == "watch_port":
-            print(type(value), value)
+            if verbose:
+                print(type(value), value)
             if type(value) is not bytes:
                 raise UserError("watch_port must be a byte string")
         super().__setattr__(name, value)
@@ -1601,7 +1609,8 @@ For information about how to read table entries, use <self>.read?
             # TODO(antonin): should we do a better job and handle other cases (a field is set while
             # is_default is set to True)?
             if value is True and self.match._count() > 0:
-                print("Clearing match key because entry is now default")
+                if verbose:
+                    print("Clearing match key because entry is now default")
                 self.match.clear()
         elif name == "member_id":
             self._action_spec_set_member(value)
@@ -2580,7 +2589,8 @@ You may also use <self>.set(<md_name>='<value>')
 
     def __getitem__(self, name):
         _ = self._get_md_info(name)
-        print(self._md.get(name, "Unset"))
+        if verbose:
+            print(self._md.get(name, "Unset"))
 
     def _parse_md(self, value, md_info):
         if type(value) is not str:

--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -39,7 +39,6 @@ import queue
 
 context = Context()
 client = None
-verbose = False
 
 
 class UserUsageError(UserError):
@@ -358,14 +357,14 @@ You may also use <self>.set(<f>='<value>')
         fullname = self._full_field_name(name)
         field_info = self._get_mf(fullname)
         self._mk[fullname] = self._parse_mf(value, field_info)
-        if verbose:
+        if context.do_printing:
             print(self._mk[fullname])
 
     def __getitem__(self, name):
         fullname = self._full_field_name(name)
         f = self._mk.get(fullname, None)
         if f is None:
-            if verbose:
+            if context.do_printing:
                 print("Unset")
         return f
 
@@ -448,7 +447,7 @@ You may also use <self>.set(<f>='<value>')
                 transformed = True
                 barray[i] = 0
         if transformed:
-            if verbose:
+            if context.do_printing:
                 print("LPM value was transformed to conform to the P4Runtime"
                       "spec (trailing bits must be unset)")
         mf.lpm.value = bytes(bytes_utils.make_canonical_if_option_set(barray))
@@ -481,7 +480,7 @@ You may also use <self>.set(<f>='<value>')
                 transformed = True
                 barray[i] = barray[i] & mask[i]
         if transformed:
-            if verbose:
+            if context.do_printing:
                 print("Ternary value was transformed to conform to the"
                       " P4Runtime spec (masked off bits must be unset)")
         mf.ternary.value = bytes(bytes_utils.make_canonical_if_option_set(barray))
@@ -603,14 +602,14 @@ class Action:
     def __setitem__(self, name, value):
         param_info = self._get_param(name)
         self._param_values[name] = self._parse_param(value, param_info)
-        if verbose:
+        if context.do_printing:
             print(self._param_values[name])
 
     def __getitem__(self, name):
         _ = self._get_param(name)
         f = self._param_values.get(name, None)
         if f is None:
-            if verbose:
+            if context.do_printing:
                 print("Unset")
         return f
 
@@ -1084,7 +1083,7 @@ class OneshotAction:
             if type(value) is not int:
                 raise UserError("watch must be an integer")
         elif name == "watch_port":
-            if verbose:
+            if context.do_printing:
                 print(type(value), value)
             if type(value) is not bytes:
                 raise UserError("watch_port must be a byte string")
@@ -1609,7 +1608,7 @@ For information about how to read table entries, use <self>.read?
             # TODO(antonin): should we do a better job and handle other cases (a field is set while
             # is_default is set to True)?
             if value is True and self.match._count() > 0:
-                if verbose:
+                if context.do_printing:
                     print("Clearing match key because entry is now default")
                 self.match.clear()
         elif name == "member_id":
@@ -2589,7 +2588,7 @@ You may also use <self>.set(<md_name>='<value>')
 
     def __getitem__(self, name):
         _ = self._get_md_info(name)
-        if verbose:
+        if context.do_printing:
             print(self._md.get(name, "Unset"))
 
     def _parse_md(self, value, md_info):
@@ -2937,7 +2936,8 @@ def setup(device_id=1,
           election_id=(1, 0),
           role_name=None,
           config=None,
-          ssl_options=None):
+          ssl_options=None,
+          do_printing=True):
     global client
     logging.debug("Creating P4Runtime client")
     client = P4RuntimeClient(device_id, grpc_addr, election_id, role_name, ssl_options)
@@ -2975,6 +2975,7 @@ def setup(device_id=1,
 
     logging.debug("Parsing P4Info message")
     context.set_p4info(p4info)
+    context.set_do_printing(do_printing)
 
 
 def teardown():

--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -40,6 +40,9 @@ import queue
 context = Context()
 client = None
 
+def _print(*args, **kwargs):
+    if global_options.get_option(Options.verbose):
+        print(*args, **kwargs)
 
 class UserUsageError(UserError):
     def __init__(self, usage):
@@ -357,15 +360,13 @@ You may also use <self>.set(<f>='<value>')
         fullname = self._full_field_name(name)
         field_info = self._get_mf(fullname)
         self._mk[fullname] = self._parse_mf(value, field_info)
-        if context.do_printing:
-            print(self._mk[fullname])
+        _print(self._mk[fullname])
 
     def __getitem__(self, name):
         fullname = self._full_field_name(name)
         f = self._mk.get(fullname, None)
         if f is None:
-            if context.do_printing:
-                print("Unset")
+            _print("Unset")
         return f
 
     def _parse_mf(self, s, field_info):
@@ -447,9 +448,8 @@ You may also use <self>.set(<f>='<value>')
                 transformed = True
                 barray[i] = 0
         if transformed:
-            if context.do_printing:
-                print("LPM value was transformed to conform to the P4Runtime"
-                      "spec (trailing bits must be unset)")
+            _print("LPM value was transformed to conform to the P4Runtime spec "
+                   "(trailing bits must be unset)")
         mf.lpm.value = bytes(bytes_utils.make_canonical_if_option_set(barray))
         return mf
 
@@ -480,9 +480,8 @@ You may also use <self>.set(<f>='<value>')
                 transformed = True
                 barray[i] = barray[i] & mask[i]
         if transformed:
-            if context.do_printing:
-                print("Ternary value was transformed to conform to the"
-                      " P4Runtime spec (masked off bits must be unset)")
+            _print("Ternary value was transformed to conform to the P4Runtime spec "
+                   "(masked off bits must be unset)")
         mf.ternary.value = bytes(bytes_utils.make_canonical_if_option_set(barray))
         mf.ternary.mask = bytes_utils.make_canonical_if_option_set(mask)
         return mf
@@ -602,15 +601,13 @@ class Action:
     def __setitem__(self, name, value):
         param_info = self._get_param(name)
         self._param_values[name] = self._parse_param(value, param_info)
-        if context.do_printing:
-            print(self._param_values[name])
+        _print(self._param_values[name])
 
     def __getitem__(self, name):
         _ = self._get_param(name)
         f = self._param_values.get(name, None)
         if f is None:
-            if context.do_printing:
-                print("Unset")
+            _print("Unset")
         return f
 
     def _parse_param(self, s, param_info):
@@ -1083,8 +1080,7 @@ class OneshotAction:
             if type(value) is not int:
                 raise UserError("watch must be an integer")
         elif name == "watch_port":
-            if context.do_printing:
-                print(type(value), value)
+            _print(type(value), value)
             if type(value) is not bytes:
                 raise UserError("watch_port must be a byte string")
         super().__setattr__(name, value)
@@ -1608,8 +1604,7 @@ For information about how to read table entries, use <self>.read?
             # TODO(antonin): should we do a better job and handle other cases (a field is set while
             # is_default is set to True)?
             if value is True and self.match._count() > 0:
-                if context.do_printing:
-                    print("Clearing match key because entry is now default")
+                _print("Clearing match key because entry is now default")
                 self.match.clear()
         elif name == "member_id":
             self._action_spec_set_member(value)
@@ -2588,8 +2583,7 @@ You may also use <self>.set(<md_name>='<value>')
 
     def __getitem__(self, name):
         _ = self._get_md_info(name)
-        if context.do_printing:
-            print(self._md.get(name, "Unset"))
+        _print(self._md.get(name, "Unset"))
 
     def _parse_md(self, value, md_info):
         if type(value) is not str:
@@ -2937,7 +2931,7 @@ def setup(device_id=1,
           role_name=None,
           config=None,
           ssl_options=None,
-          do_printing=True):
+          verbose=True):
     global client
     logging.debug("Creating P4Runtime client")
     client = P4RuntimeClient(device_id, grpc_addr, election_id, role_name, ssl_options)
@@ -2975,7 +2969,7 @@ def setup(device_id=1,
 
     logging.debug("Parsing P4Info message")
     context.set_p4info(p4info)
-    context.set_do_printing(do_printing)
+    global_options["verbose"] = verbose
 
 
 def teardown():

--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -29,7 +29,7 @@ from p4runtime_sh.p4runtime import (P4RuntimeClient, P4RuntimeException, parse_p
 from p4.v1 import p4runtime_pb2
 from p4.config.v1 import p4info_pb2
 from . import bytes_utils
-from . global_options import global_options
+from . global_options import global_options, Options
 from .context import P4RuntimeEntity, P4Type, Context
 from .utils import UserError, InvalidP4InfoError
 import google.protobuf.text_format

--- a/p4runtime_sh/shell.py
+++ b/p4runtime_sh/shell.py
@@ -40,9 +40,11 @@ import queue
 context = Context()
 client = None
 
+
 def _print(*args, **kwargs):
     if global_options.get_option(Options.verbose):
         print(*args, **kwargs)
+
 
 class UserUsageError(UserError):
     def __init__(self, usage):


### PR DESCRIPTION
This is only a draft of a change to show the kind of change I am thinking about -- I do not expect this PR to be in its final form for merging.

The `print()` calls spread throughout shell.py, while probably exactly what someone wants when using p4runtime-shell interactively, can be fairly noisy in a situation where one is using p4runtime-shell in a batch situation, e.g. a PTF test.  In such a context, it would be nice to have an option to make p4runtime-shell not do all of these print calls.

If this seems reasonable, I am open to suggestions on exactly how to control this printing on/off.  For example, it would probably be nice for backwards compatibility to have these `print` calls enabled by default, and require some extra configuration call to the library that disables them.