### PR TITLE
Replace old ipaddr Python package with ipaddress

### DIFF
--- a/p4runtime_sh/bytes_utils.py
+++ b/p4runtime_sh/bytes_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from ipaddr import IPv4Address, IPv6Address, AddressValueError
+from ipaddress import IPv4Address, IPv6Address, AddressValueError
 from . global_options import global_options, Options
 from .utils import UserError
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ python_requires = >=3.6
 setup_requires =
     setuptools_scm
 install_requires =
-    ipaddr == 2.2.0
     jedi == 0.17.2
     ipython >= 7.31.1, == 7.31.*; python_version>='3.7'
     ipython >= 7.16.3, == 7.16.*; python_version<'3.7'


### PR DESCRIPTION
Use of ipaddr has been replaced with ipaddress in behavioral-model and p4c repos now.  Seems reasonable to do so here as well.