### PR TITLE
Make a Merge() call allow not-yet-recognized new fields in P4Info files

### DIFF
--- a/p4runtime_sh/p4runtime.py
+++ b/p4runtime_sh/p4runtime.py
@@ -289,7 +289,7 @@ class P4RuntimeClient:
         with open(p4info_path, 'r') as f1:
             with open(bin_path, 'rb') as f2:
                 try:
-                    google.protobuf.text_format.Merge(f1.read(), req.config.p4info)
+                    google.protobuf.text_format.Merge(f1.read(), req.config.p4info, allow_unknown_field=True)
                 except google.protobuf.text_format.ParseError:
                     logging.error("Error when parsing P4Info")
                     raise

--- a/p4runtime_sh/p4runtime.py
+++ b/p4runtime_sh/p4runtime.py
@@ -289,7 +289,8 @@ class P4RuntimeClient:
         with open(p4info_path, 'r') as f1:
             with open(bin_path, 'rb') as f2:
                 try:
-                    google.protobuf.text_format.Merge(f1.read(), req.config.p4info, allow_unknown_field=True)
+                    google.protobuf.text_format.Merge(f1.read(), req.config.p4info,
+                                                      allow_unknown_field=True)
                 except google.protobuf.text_format.ParseError:
                     logging.error("Error when parsing P4Info")
                     raise


### PR DESCRIPTION
This is helpful when p4c adds new P4Info fields to the P4Info files it generates, but the consumers have not yet all been updated to recognize them.  The most recent example of this in 2024-Aug is the initial_default_action field of Table messages.