### PR TITLE
LPM Masking: Fix masking for fields with bitwidth non divisable by 8.

### DIFF
--- a/p4runtime_sh/testdata/unittest.p4info.pb.txt
+++ b/p4runtime_sh/testdata/unittest.p4info.pb.txt
@@ -52,6 +52,34 @@ tables {
 }
 tables {
   preamble {
+    id: 33567647
+    name: "LpmTwo"
+    alias: "LpmTwo"
+  }
+  match_fields {
+    id: 1
+    name: "header_test.field20"
+    bitwidth: 20
+    match_type: LPM
+  }
+  match_fields {
+    id: 2
+    name: "header_test.field2"
+    bitwidth: 2
+    match_type: LPM
+  }
+  action_refs {
+    id: 16783703
+  }
+  action_refs {
+    id: 16800567
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 512
+}
+tables {
+  preamble {
     id: 33584148
     name: "TernaryOne"
     alias: "TernaryOne"


### PR DESCRIPTION
When prefix and/or bitwidth are not aligend to size of a byte, we must make sure the mask is applied correctly to all bits in field. Until now, the logic expected to find maximum of one byte that needs special masking, and that masking is relative to the "beginning" (MSB bits) of the bytes. This caused issues with fields that are smaller than a byte. Another issue, some fields and prefixed might need some bits of a the "first" and "last" byte in the prefix to be masked, for example: Field bitwidth = 20
Prefix length = 16
Mask should be = 0b11111111111111110000
Since we are representing in byte arrays, in bytes we get -> 00001111 11111111 11110000  (24 bits, 3 bytes)

Old implmentation disregarded the first 2 bytes and only masked the last byte (0b11110000).

Both issues are fixed in this commit, by this flow:
1. Utilizing prefix byte array, which is aligned to number of bytes needed to represent bitwidth in bytes.
2. Creating a mask for entire field, according to prefix length.
3. Applying it to all bits in prefix length.

Issue: https://github.com/p4lang/p4runtime-shell/issues/146