### PR TITLE
Add back top level LICENSE file as symbolic link to LICENSES/Apache-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/Apache-2.0.txt


### PR DESCRIPTION
In future Github may have better auto-recognition of LICENSES directory, but for now a top level LICENSE file is a useful thing to have still, even when using REUSE.